### PR TITLE
Add ability to skip docker login

### DIFF
--- a/packages/plugins/docker/src/lib/normalize-config.spec.ts
+++ b/packages/plugins/docker/src/lib/normalize-config.spec.ts
@@ -7,6 +7,7 @@ describe('normalize config', () => {
 
     const expectedConfig = {
       name: 'test123',
+      skipLogin: false,
       publishMajorTag: false,
       publishMinorTag: false,
       publishLatestTag: true,
@@ -21,6 +22,7 @@ describe('normalize config', () => {
   it('should return specified values when additional config is specified', () => {
     const testConfig = {
       name: 'test123',
+      skipLogin: true,
       publishMajorTag: true,
       publishMinorTag: true,
       publishLatestTag: false,
@@ -29,6 +31,7 @@ describe('normalize config', () => {
 
     const expectedConfig = {
       name: 'test123',
+      skipLogin: true,
       publishMajorTag: true,
       publishMinorTag: true,
       publishLatestTag: false,

--- a/packages/plugins/docker/src/lib/normalize-config.ts
+++ b/packages/plugins/docker/src/lib/normalize-config.ts
@@ -3,6 +3,7 @@ import { PluginConfig } from './plugin-config.interface';
 export function normalizeConfig(pluginConfig: PluginConfig): PluginConfig {
   return {
     registryUrl: '',
+    skipLogin: false,
     publishMajorTag: false,
     publishMinorTag: false,
     publishLatestTag: true,

--- a/packages/plugins/docker/src/lib/plugin-config.interface.ts
+++ b/packages/plugins/docker/src/lib/plugin-config.interface.ts
@@ -1,5 +1,6 @@
 export interface PluginConfig {
   name: string;
+  skipLogin?: boolean;
   registryUrl?: string;
   publishLatestTag?: boolean;
   publishMajorTag?: boolean;

--- a/packages/plugins/docker/src/lib/verify.spec.ts
+++ b/packages/plugins/docker/src/lib/verify.spec.ts
@@ -19,6 +19,11 @@ describe('verify', () => {
       name: 'test',
     } as PluginConfig;
 
+    const pluginConfigNoLogin = {
+      name: 'test',
+      skipLogin: true,
+    } as PluginConfig;
+
     const context = {
       nextRelease: {
         version: '1.1.1',
@@ -79,6 +84,12 @@ describe('verify', () => {
         new Error('test error')
       );
       await expect(verifyConditions(pluginConfig, context)).rejects.toThrow();
+    });
+
+    it('should skip logging in to docker if set to in config', async () => {
+      expect(verifyConditions(pluginConfigNoLogin, context)).resolves;
+
+      expect(execa).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/plugins/docker/src/lib/verify.ts
+++ b/packages/plugins/docker/src/lib/verify.ts
@@ -4,6 +4,8 @@ import { PluginConfig } from './plugin-config.interface';
 
 export async function verifyConditions(pluginConfig: PluginConfig, { logger }) {
   pluginConfig = normalizeConfig(pluginConfig);
+  if ( pluginConfig.skipLogin ) return;
+  
   for (const envVar of ['DOCKER_USERNAME', 'DOCKER_PASSWORD']) {
     if (!process.env[envVar]) {
       throw new Error(`Environment variable ${envVar} is not set`);


### PR DESCRIPTION
I've added the ability to skip logging in to docker in the plugin configuration. 
This provides the option for you to login in to your registry in a separate step in your CI environment.