### PR TITLE
feat(docker): all running with docker plugin with tagged version

### DIFF
--- a/packages/plugins/docker/src/lib/normalize-config.spec.ts
+++ b/packages/plugins/docker/src/lib/normalize-config.spec.ts
@@ -7,6 +7,7 @@ describe('normalize config', () => {
 
     const expectedConfig = {
       name: 'test123',
+      fullname: 'test123',
       skipLogin: false,
       publishChannelTag: true,
       registry: '',
@@ -17,7 +18,7 @@ describe('normalize config', () => {
     expect(normConfig).toEqual(expectedConfig);
   });
 
-  it('should return specified values when additional config is specified', () => {
+  it('should return specified values when additional config if specified', () => {
     const testConfig = {
       name: 'test123',
       skipLogin: true,
@@ -27,6 +28,50 @@ describe('normalize config', () => {
 
     const expectedConfig = {
       name: 'test123',
+      fullname: 'test123',
+      skipLogin: true,
+      publishChannelTag: false,
+      registry: 'https://my-private-repo',
+    } as PluginConfig;
+
+    const normConfig = normalizeConfig(testConfig);
+
+    expect(normConfig).toEqual(expectedConfig);
+  });
+
+  it('should normalize docker name and tag if specified', () => {
+    const testConfig = {
+      name: 'test123:not-latest-but-pr',
+      skipLogin: true,
+      publishChannelTag: false,
+      registry: 'https://my-private-repo',
+    } as PluginConfig;
+
+    const expectedConfig = {
+      name: 'test123',
+      fullname: 'test123:not-latest-but-pr',
+      skipLogin: true,
+      publishChannelTag: false,
+      registry: 'https://my-private-repo',
+    } as PluginConfig;
+
+    const normConfig = normalizeConfig(testConfig);
+
+    expect(normConfig).toEqual(expectedConfig);
+  });
+
+  it('should normalize docker name and tag event in sha format if specified', () => {
+    const testConfig = {
+      name: 'test123@sha256:49cb0d58e7fee6e86d061f152bbbd529cf41059e9da00868babed2380c4a3d61',
+      skipLogin: true,
+      publishChannelTag: false,
+      registry: 'https://my-private-repo',
+    } as PluginConfig;
+
+    const expectedConfig = {
+      name: 'test123',
+      fullname:
+        'test123@sha256:49cb0d58e7fee6e86d061f152bbbd529cf41059e9da00868babed2380c4a3d61',
       skipLogin: true,
       publishChannelTag: false,
       registry: 'https://my-private-repo',

--- a/packages/plugins/docker/src/lib/normalize-config.ts
+++ b/packages/plugins/docker/src/lib/normalize-config.ts
@@ -1,10 +1,18 @@
 import { PluginConfig } from './plugin-config.interface';
 
 export function normalizeConfig(pluginConfig: PluginConfig): PluginConfig {
+  let name = pluginConfig.name;
+  if (name.includes('@sha')) {
+    name = name.split('@')[0];
+  } else if (name.includes(':')) {
+    name = name.split(':')[0];
+  }
   return {
     registry: '',
     skipLogin: false,
     publishChannelTag: true,
     ...pluginConfig,
+    fullname: pluginConfig.name,
+    name,
   };
 }

--- a/packages/plugins/docker/src/lib/plugin-config.interface.ts
+++ b/packages/plugins/docker/src/lib/plugin-config.interface.ts
@@ -1,5 +1,6 @@
 export interface PluginConfig {
   name: string;
+  fullname?: string;
   skipLogin?: boolean;
   registry?: string;
   publishChannelTag?: boolean;

--- a/packages/plugins/docker/src/lib/publish.spec.ts
+++ b/packages/plugins/docker/src/lib/publish.spec.ts
@@ -188,4 +188,76 @@ describe('publish', () => {
     expect(context.logger.log).toBeCalledWith(`Pushing ${channelTag}`);
     expect(dockerPushMock).toHaveBeenCalledWith(channelTag, context);
   });
+
+  it('should publish with an buildTag', async () => {
+    const name = 'test';
+    const fullname = `${name}:pr-tag`;
+    const version = '2.3.4';
+
+    const pluginConfig = { name: fullname } as PluginConfig;
+
+    const context: Context = {
+      ...baseContext,
+      nextRelease: {
+        version,
+        type: BranchType.Release,
+      },
+    };
+
+    const exactTag = `${name}:${version}`;
+    const channelTag = `${name}:latest`;
+
+    await publish(pluginConfig, context);
+    expect(context.logger.log).toBeCalledWith(
+      `Tagging ${fullname} as ${exactTag}`
+    );
+    expect(dockerTagMock).toHaveBeenCalledWith(fullname, exactTag, context);
+
+    expect(context.logger.log).toBeCalledWith(
+      `Tagging ${fullname} as ${channelTag}`
+    );
+    expect(dockerTagMock).toHaveBeenCalledWith(fullname, channelTag, context);
+
+    expect(context.logger.log).toBeCalledWith(`Pushing ${exactTag}`);
+    expect(dockerPushMock).toHaveBeenCalledWith(exactTag, context);
+
+    expect(context.logger.log).toBeCalledWith(`Pushing ${channelTag}`);
+    expect(dockerPushMock).toHaveBeenCalledWith(channelTag, context);
+  });
+
+  it('should publish with a sha like buildTag', async () => {
+    const name = 'test';
+    const fullname = 'test@sha256:12345';
+    const version = '3.4.5';
+
+    const pluginConfig = { name: fullname } as PluginConfig;
+
+    const context: Context = {
+      ...baseContext,
+      nextRelease: {
+        version,
+        type: BranchType.Release,
+      },
+    };
+
+    const exactTag = `${name}:${version}`;
+    const channelTag = `${name}:latest`;
+
+    await publish(pluginConfig, context);
+    expect(context.logger.log).toBeCalledWith(
+      `Tagging ${fullname} as ${exactTag}`
+    );
+    expect(dockerTagMock).toHaveBeenCalledWith(fullname, exactTag, context);
+
+    expect(context.logger.log).toBeCalledWith(
+      `Tagging ${fullname} as ${channelTag}`
+    );
+    expect(dockerTagMock).toHaveBeenCalledWith(fullname, channelTag, context);
+
+    expect(context.logger.log).toBeCalledWith(`Pushing ${exactTag}`);
+    expect(dockerPushMock).toHaveBeenCalledWith(exactTag, context);
+
+    expect(context.logger.log).toBeCalledWith(`Pushing ${channelTag}`);
+    expect(dockerPushMock).toHaveBeenCalledWith(channelTag, context);
+  });
 });

--- a/packages/plugins/docker/src/lib/publish.ts
+++ b/packages/plugins/docker/src/lib/publish.ts
@@ -7,7 +7,7 @@ import { PluginConfig } from './plugin-config.interface';
 export async function publish(pluginConfig: PluginConfig, context: Context) {
   pluginConfig = normalizeConfig(pluginConfig);
 
-  const { name, registry } = pluginConfig;
+  const { name, fullname, registry } = pluginConfig;
   const {
     nextRelease: { version, channel },
     logger,
@@ -19,8 +19,8 @@ export async function publish(pluginConfig: PluginConfig, context: Context) {
   tags = tags.map((tag) => `${registryPath}${name}:${tag}`);
 
   for (const tag of tags) {
-    logger.log(`Tagging ${name} as ${tag}`);
-    const { stdout } = await dockerTag(name, tag, context);
+    logger.log(`Tagging ${fullname} as ${tag}`);
+    const { stdout } = await dockerTag(fullname, tag, context);
     logger.log(stdout);
   }
 


### PR DESCRIPTION
A small PR that allow to use your docker plugin with docker image name with a tag.

For Eg:
```
docker build -t username/imagename:pr-42 .
npm run semantic-release
```
